### PR TITLE
Fix broken backend build

### DIFF
--- a/services/backend/src/routes/index.ts
+++ b/services/backend/src/routes/index.ts
@@ -3,7 +3,7 @@ import { HELLO_WORLD } from '@theomer77/some-package';
 
 const router = Router();
 
-router.get('/', (req, res) => {
+router.get('/', (_req, res) => {
   res.json({ success: true, message: HELLO_WORLD });
 });
 

--- a/services/backend/tsconfig.json
+++ b/services/backend/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": { "paths": { "@/*": ["./src/*"] }, "module": "CommonJS" },
-  "include": ["src"],
+  "compilerOptions": { "paths": { "@/*": ["./src/*"] } },
+  "include": ["src"]
 }


### PR DESCRIPTION
- Fix TS build error by removing `"module": "CommonJS"` from backend tsconfig.json
- Fix ESBuild lint error in routes/index.ts where `req` is never used, by renaming it to `_req`