### PR TITLE
Fix FROM-as casing in dockerfiles

### DIFF
--- a/services/backend/Dockerfile.dev
+++ b/services/backend/Dockerfile.dev
@@ -1,6 +1,6 @@
 ARG SERVICE_NAME=backend
 
-FROM node:20.15.1-alpine3.20 as base
+FROM node:20.15.1-alpine3.20 AS base
 ARG SERVICE_NAME
 ENV SERVICE_NAME ${SERVICE_NAME}
 

--- a/services/backend/Dockerfile.prod
+++ b/services/backend/Dockerfile.prod
@@ -1,11 +1,11 @@
 ARG SERVICE_NAME=backend
 ARG PORT=80
 
-FROM node:20.15.1-alpine3.20 as base
+FROM node:20.15.1-alpine3.20 AS base
 WORKDIR /app
 RUN corepack enable pnpm
 
-FROM base as builder
+FROM base AS builder
 ARG SERVICE_NAME
 
 WORKDIR /app
@@ -21,7 +21,7 @@ RUN ./packages/run-all.sh build && \
   find ./packages -mindepth 2 \( ! -name 'package.json' -a ! -path '*/dist/*' \) \
   -delete 2>/dev/null
 
-FROM base as runner
+FROM base AS runner
 ARG SERVICE_NAME
 ARG PORT
 

--- a/services/frontend/Dockerfile.dev
+++ b/services/frontend/Dockerfile.dev
@@ -1,6 +1,6 @@
 ARG SERVICE_NAME=frontend
 
-FROM node:20.15.1-alpine3.20 as base
+FROM node:20.15.1-alpine3.20 AS base
 ARG SERVICE_NAME
 ENV SERVICE_NAME ${SERVICE_NAME}
 

--- a/services/frontend/Dockerfile.prod
+++ b/services/frontend/Dockerfile.prod
@@ -1,7 +1,7 @@
 ARG SERVICE_NAME=frontend
 ARG PORT=80
 
-FROM node:20.15.1-alpine3.20 as builder
+FROM node:20.15.1-alpine3.20 AS builder
 ARG SERVICE_NAME
 
 WORKDIR /app

--- a/services/package-builder/Dockerfile.dev
+++ b/services/package-builder/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20.15.1-alpine3.20 as base
+FROM node:20.15.1-alpine3.20 AS base
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json \


### PR DESCRIPTION
Fix the following warning that appears during docker build:
`WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match `