### PR TITLE
ESLint: Update next `folder-naming-convention` for app router

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -9,4 +9,13 @@ module.exports = {
   env: { node: true },
   settings: { 'import/resolver': { typescript: { project } } },
   ignorePatterns: ['.*.js', 'node_modules/'],
+  rules: {
+    'check-file/folder-naming-convention': [
+      'warn',
+      {
+        'src/app/**': 'NEXT_JS_APP_ROUTER_CASE',
+        'src/!(app)/**/*': 'KEBAB_CASE',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Allow app router naming patterns in Next.js projects app directory, based on kebab-case; For other directories keep just kebab-case.